### PR TITLE
Intelチップ用にnodeへのPATHを追加

### DIFF
--- a/github.5m.js
+++ b/github.5m.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S PATH="${PATH}:/opt/homebrew/bin" node
+#!/usr/bin/env -S PATH="${PATH}:/opt/homebrew/bin:/usr/local/bin" node
 
 // meta
 // <xbar.title>GitHub</xbar.title>


### PR DESCRIPTION
homebrewからインストールされるpathがAppli siliconとIntal chipで異なったので、両方のパスに対応させたいです。

M1端末とIntel端末両方で問題なく動作することを確認済みです。